### PR TITLE
chore: remove react/jsx-runtime from bundle

### DIFF
--- a/src/lib/components/atoms/at-button/at-button.test.tsx
+++ b/src/lib/components/atoms/at-button/at-button.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { AtButton } from './index'
 
-// The two tests marked with concurrent will be run in parallel
 describe('AtButton', () => {
   it('should render', async () => {
     const label = 'test button'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,10 +27,11 @@ const app = async (): Promise<UserConfigExport> => {
         fileName: (format) => `${name}.${format}.js`,
       },
       rollupOptions: {
-        external: ['react', 'react-dom', 'tailwindcss'],
+        external: ['react', 'react/jsx-runtime', 'react-dom', 'tailwindcss'],
         output: {
           globals: {
             react: 'React',
+            'react/jsx-runtime': 'react/jsx-runtime',
             'react-dom': 'ReactDOM',
             tailwindcss: 'tailwindcss',
           },


### PR DESCRIPTION
As discussed here #69 I'm removing `react/jsx-runtime` from the bundle. After some help and research I agree this makes sense. It will reduce the size of the bundle too, making this library even more performant!
