### PR TITLE
Chore/add GitHub publishing example

### DIFF
--- a/.github/examples/github-release-please.yml
+++ b/.github/examples/github-release-please.yml
@@ -1,0 +1,56 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release
+        id: release
+        if: ${{ github.ref_name == 'main' }}
+        uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          default-branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        if: ${{ steps.release.outputs.releases_created }}
+        with:
+          version: 8
+
+      # Setup .npmrc file to publish to npm
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'pnpm'
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: CI
+        run: pnpm install --frozen-lockfile
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Build
+        run: pnpm build:lib
+        if: ${{ steps.release.outputs.releases_created }}
+
+      - name: Publish
+        run: pnpm publish
+        if: ${{ steps.release.outputs.releases_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": false,
   "version": "2.0.3",
   "packageManager": "pnpm@8.4.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IgnacioNMiranda/vite-component-library-template"
+  },
   "main": "./dist/vite-component-library-template.umd.js",
   "module": "./dist/vite-component-library-template.es.js",
   "types": "./dist/index.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,13 @@ import { UserConfigExport } from 'vite'
 import { name } from './package.json'
 
 const app = async (): Promise<UserConfigExport> => {
+  /**
+   * Removes everything before the last
+   * @octocat/library-repo -> library-repo
+   * vite-component-library-template -> vite-component-library-template
+   */
+  const formattedName = name.match(/[^/]+$/)?.[0] ?? name
+
   return defineConfig({
     plugins: [
       react(),
@@ -22,9 +29,9 @@ const app = async (): Promise<UserConfigExport> => {
     build: {
       lib: {
         entry: path.resolve(__dirname, 'src/lib/index.ts'),
-        name,
+        name: formattedName,
         formats: ['es', 'umd'],
-        fileName: (format) => `${name}.${format}.js`,
+        fileName: (format) => `${formattedName}.${format}.js`,
       },
       rollupOptions: {
         external: ['react', 'react/jsx-runtime', 'react-dom', 'tailwindcss'],


### PR DESCRIPTION
# Chore

Considering the requests I've received, I added an example workflow file for publishing to Github packages. I'll write a post explaining how to do it and will be available in the README (:

* Add Github release workflow file
* Add 'repository' key in package.json. Useful for packages that are published in the Github package registry.
* Update vite build step to format the name property removing the organization from it (this is to have compatibility with package.json names that includes the organization such as `@octocat/my-library`). If this is not included, The dist folder is not generated correctly